### PR TITLE
Sticky header

### DIFF
--- a/app/assets/stylesheets/header.sass
+++ b/app/assets/stylesheets/header.sass
@@ -13,7 +13,7 @@
 #heading
   background: white
   border-bottom: 1px solid $greyBorder
-  margin-top: 57px
+  margin-top: 56px
 
 .breadcrumb
   background: white

--- a/app/assets/stylesheets/header.sass
+++ b/app/assets/stylesheets/header.sass
@@ -1,9 +1,9 @@
 #top
-  background: $blue
 
   .navbar
     padding-left: 0px
     padding-right: 0px
+    background: $blue
 
 .nav-link, .navbar-brand
   color: $white
@@ -13,6 +13,7 @@
 #heading
   background: white
   border-bottom: 1px solid $greyBorder
+  margin-top: 57px
 
 .breadcrumb
   background: white

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,9 +4,7 @@
     = render 'shared/head'
   %body{class: "#{params[:controller]} #{params[:action]}"}
 
-    = render 'shared/flash_banner'
     = render 'shared/header'
-
     #main
       .container
         = yield

--- a/app/views/layouts/devise.html.haml
+++ b/app/views/layouts/devise.html.haml
@@ -4,7 +4,6 @@
     = render 'shared/head'
   %body#devise{class: "#{params[:controller]} #{params[:action]}"}
 
-    = render 'shared/flash_banner'
     = render 'shared/header'
 
     #main
@@ -15,7 +14,7 @@
             .row
               .col-md-10
                 %h1 Lorem Ipsum is simply dummy.
-                %h5 Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. 
+                %h5 Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.
 
           .col-md-5
             = yield

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -22,6 +22,7 @@
               =link_to 'Login', new_user_session_path, class: 'nav-link'
 
 #heading
+  = render 'shared/flash_banner'
   .container
     .row
       = render 'shared/breadcrumbs'

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -1,6 +1,6 @@
 #top
-  .container
-    %nav.navbar.navbar-static-top
+  %nav.navbar.navbar-fixed-top
+    .container
       %button.navbar-toggler.hidden-sm-up{"aria-controls" => "navbar-header", "data-target" => "#navbar-header", "data-toggle" => "collapse", :type => "button"}
         ☰
       #navbar-header.collapse.navbar-toggleable-xs


### PR DESCRIPTION
The flash messages is moved above of the breadcrumb bar.

Known issue: The margin above breadcrumb should going with the height of navigation bar. Currently it has a small gap between navigation bar and flash message.
