### PR TITLE
Fix product edit page

### DIFF
--- a/app/views/products/_form.html.haml
+++ b/app/views/products/_form.html.haml
@@ -28,5 +28,5 @@
           .col-md-12
             = f.label :category_id
           .col-md-12#custom-dropdown
-            = f.select :category_id, options_for_select(@categories.collect{ |u| [u.title, u.id] })
+            = f.select :category_id, options_for_select(@categories.collect{ |u| [u.title, u.id]}, selected = [@product.category.title, @product.category.id] )
       = f.submit(class: "btn btn-primary")

--- a/app/views/products/_form.html.haml
+++ b/app/views/products/_form.html.haml
@@ -1,4 +1,3 @@
-
 .row
   .card.card-block.col-md-12
     %h3.card-title= form_header

--- a/app/views/products/_form.html.haml
+++ b/app/views/products/_form.html.haml
@@ -30,4 +30,4 @@
             = f.label :category_id
           .col-md-12#custom-dropdown
             = f.select :category_id, options_for_select(@categories.collect{ |u| [u.title, u.id] })
-      = f.submit "Create", class: "btn btn-primary"
+      = f.submit(class: "btn btn-primary")


### PR DESCRIPTION
Improve wording on edit product page.
Fix the category pre-populate bug.

Known development environment issue:
Currently it assumes all products belong to a category, even _uncategorized_. So products created before selecting an certain category will cause a crash if going into edit product page.
